### PR TITLE
fix: restricting entire contenttypes

### DIFF
--- a/src/Handler/Checker.php
+++ b/src/Handler/Checker.php
@@ -56,6 +56,12 @@ class Checker
         $restrictContenttype = (array) $this->config['contenttype'];
 
         foreach($this->app['config']->get('contenttypes') as $key => $ct) {
+            //check if the slug(singular or multiple) of this contenttype matches
+            //the one of our request. If not we should skip this round
+            if(!(($ct['slug'] == $path) || ($ct['singular_slug'] == $path))){
+                continue;
+            }
+
             //Check if members-only is the same contenttype in our config file
             if ((in_array($ct['slug'], $restrictContenttype)) || (in_array($ct['singular_slug'], $restrictContenttype))) {
                 $this->checkSessionAndRedirect();

--- a/src/Handler/Checker.php
+++ b/src/Handler/Checker.php
@@ -58,7 +58,7 @@ class Checker
         foreach($this->app['config']->get('contenttypes') as $key => $ct) {
             //check if the slug(singular or multiple) of this contenttype matches
             //the one of our request. If not we should skip this round
-            if(!(($ct['slug'] == $path) || ($ct['singular_slug'] == $path))){
+            if ($ct['slug'] != $path && $ct['singular_slug'] != $path){
                 continue;
             }
 


### PR DESCRIPTION
Hi,

I fixed the issue described in issue #21 

Problem was, that the redirect was triggered if __any__ of the defined contenttypes (`$this->app['config']->get('contenttypes')`) is present in the contenttypes we want to password-protect (this probably always is the case :) ).

I added a prior check if the contenttype of the request matches the contenttype of the current foreach-round - and only then go on with the check if or of-not password-protect.

