### PR TITLE
Added support for custom labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Modifying the public Form page
 -----------------------------------
 
 You can change the form being asked for in the `config.yml` by changing the
-`form` parameter. An example of the form is under `templates/passwordform.twig`.
+`form` parameter. An example of the form is under `templates/passwordform.twig`.  
+If you want to use the provided form-template, but with custom labels, you
+can set or modify them in `config.yml`.
 
 Changing passwords without modifying the YML file
 -------------------------------------------------

--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -13,8 +13,14 @@ visitors:
 # note: this is NOT an URL, but must be a contenttype/slug combination.
 redirect: 'page/login'
 
+# Set custom labels for Buttons, Inputs and messages
 message_correct: "Thank you for providing the correct password. You now have access to the protected pages."
 message_wrong: "The password was not correct. Try again."
+# label_username: "Username"
+# label_password: "Password"
+# label_login: "Log on!"
+# label_logout: "Log off!"
+# message_alreadyloggedin: "You are already logged on. Click the button below to log off."
 
 # Template to use for the password form. Best practice is to copy the form to your
 # own theme folder, and modify it there.

--- a/src/Twig/PasswordProtect.php
+++ b/src/Twig/PasswordProtect.php
@@ -67,8 +67,8 @@ class PasswordProtect
         }
 
         //prepare custom labels
-        function getConfigOrDefault($array, $key, $default){
-          return array_key_exists($key, $array) ? $array[$key] : $default;
+        function getConfigOrDefault($config, $key, $default){
+          return array_key_exists($key, $config) ? $config[$key] : $default;
         }
         $labels = [];
         $labels['username'] = getConfigOrDefault($this->config,'label_username',"username");

--- a/src/Twig/PasswordProtect.php
+++ b/src/Twig/PasswordProtect.php
@@ -66,14 +66,25 @@ class PasswordProtect
             $notices[] = sprintf("<p class='message-wrong'>%s</p>", $message);
         }
 
+        //prepare custom labels
+        function getConfigOrDefault($array, $key, $default){
+          return array_key_exists($key, $array) ? $array[$key] : $default;
+        }
+        $labels = [];
+        $labels['username'] = getConfigOrDefault($this->config,'label_username',"username");
+        $labels['password'] = getConfigOrDefault($this->config,'label_password',"password");
+        $labels['login'] = getConfigOrDefault($this->config,'label_login',"Log on!");
+        $labels['logout'] = getConfigOrDefault($this->config,'label_logout',"Log off!");
+        $labels['alreadyloggedin'] = getConfigOrDefault($this->config,'message_alreadyloggedin',"You are already logged on. Click the button below to log off.");
+
         // Set up the form.
         $form = $this->app['form.factory']->createBuilder('form');
 
         if ($this->config['password_only'] == false) {
-            $form->add('username', 'text');
+            $form->add('username', 'text', ['label'=>$labels['username']]);
         }
 
-        $form->add('password', 'password');
+        $form->add('password', 'password', ['label'=>$labels['password']]);
         $form = $form->getForm();
 
         $request = $this->app['request_stack']->getCurrentRequest();
@@ -121,7 +132,8 @@ class PasswordProtect
         // Render the form, and show it it the visitor.
         $twigData = [
             'form' => $form->createView(),
-            'notice' => new \Twig_Markup(implode('\n', $notices), 'UTF-8')
+            'notice' => new \Twig_Markup(implode('\n', $notices), 'UTF-8'),
+            'labels' => $labels
         ];
 
         $html = $this->app['twig']->render($formView, $twigData);

--- a/templates/passwordform.twig
+++ b/templates/passwordform.twig
@@ -25,11 +25,11 @@
     <fieldset>
     {% if not passwordprotect_username() %}
         {{ form_widget(form) }}
-        <input class="button" type="submit" name="Log on!" value="Log on!" />
+        <input class="button" type="submit" name="{{ labels.login }}" value="{{ labels.login }}" />
     {% else %}
         <input type="hidden" id="form__token" name="form[_token]" value="{{ form._token.vars.value }}" />
-        <p>You are already logged on. Click the button below to log off.</p>
-        <input class="button" type="submit" name="Log off!" value="Log off!" />
+        <p>{{ labels.alreadyloggedin }}</p>
+        <input class="button" type="submit" name="{{ labels.logout }}" value="{{ labels.logout }}" />
     {% endif %}
     </fieldset>
 </form>


### PR DESCRIPTION
Added further support for customizing the labels of buttons, inputs and the _already-logged-in_-message.

If any of the new config-settings is not set, a default value (the originally hardcoded string) will be used, so this change should be compatible to any old `config.yml` files.